### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,9 +11,9 @@
     <div class="logo">
       <span class="logo-red">Scales<span class="arrow-up">↑</span></span><span class="logo-blue">Edge</span>
     </div>
-    <div class="menu-toggle" id="menu-toggle">
+    <button id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false" class="menu-toggle">
       <div></div><div></div><div></div>
-    </div>
+    </button>
     <ul class="dropdown-menu" id="dropdown-menu">
       <li><a href="index.html">Home</a></li>
       <li><a href="about.html">About</a></li>

--- a/contact.html
+++ b/contact.html
@@ -23,9 +23,9 @@
     <div class="logo">
       <span class="logo-red">Scales<span class="arrow-up">↑</span></span><span class="logo-blue">Edge</span>
     </div>
-    <div class="menu-toggle" id="menu-toggle">
+    <button id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false" class="menu-toggle">
       <div></div><div></div><div></div>
-    </div>
+    </button>
     <ul class="dropdown-menu" id="dropdown-menu">
       <li><a href="index.html">Home</a></li>
       <li><a href="about.html">About</a></li>

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
   <link href="style.css" rel="stylesheet"/>
 </head>
 <body>
-  <header class="navbar">
-    <div class="logo">
-      <span class="logo-red">Scales<span class="arrow-up">↑</span></span><span class="logo-blue">Edge</span>
-    </div>
-    <div class="menu-toggle" id="menu-toggle"><div></div><div></div><div></div></div>
-      <div></div><div></div><div></div>
-    </div>
-    <ul class="dropdown-menu" id="dropdown-menu">
+    <header class="navbar">
+      <div class="logo">
+        <span class="logo-red">Scales<span class="arrow-up">↑</span></span><span class="logo-blue">Edge</span>
+      </div>
+      <button id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false" class="menu-toggle">
+        <div></div><div></div><div></div>
+      </button>
+      <ul class="dropdown-menu" id="dropdown-menu">
       <li><a href="index.html">Home</a></li>
       <li><a href="about.html">About</a></li>
       <li><a href="services.html">Services</a></li>

--- a/script.js
+++ b/script.js
@@ -1,10 +1,42 @@
 document.addEventListener('DOMContentLoaded', () => {
-  // Dropdown Menu Toggle
+  // Dropdown Menu Toggle with accessibility support
   const toggle = document.getElementById('menu-toggle');
   const dropdown = document.getElementById('dropdown-menu');
-  
-  toggle.addEventListener('click', () => {
-    dropdown.classList.toggle('show');
+
+  function closeMenu() {
+    dropdown.classList.remove('show');
+    toggle.setAttribute('aria-expanded', 'false');
+  }
+
+  function toggleMenu() {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    if (expanded) {
+      closeMenu();
+    } else {
+      dropdown.classList.add('show');
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+  }
+
+  toggle.addEventListener('click', toggleMenu);
+  toggle.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggleMenu();
+    }
+  });
+
+  document.addEventListener('click', (e) => {
+    if (!dropdown.contains(e.target) && !toggle.contains(e.target)) {
+      closeMenu();
+    }
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') {
+      closeMenu();
+      toggle.focus();
+    }
   });
 
   // Copy email to clipboard with confirmation

--- a/services.html
+++ b/services.html
@@ -11,9 +11,9 @@
     <div class="logo">
       <span class="logo-red">Scales<span class="arrow-up">↑</span></span><span class="logo-blue">Edge</span>
     </div>
-    <div class="menu-toggle" id="menu-toggle">
+    <button id="menu-toggle" aria-label="Toggle navigation" aria-expanded="false" class="menu-toggle">
       <div></div><div></div><div></div>
-    </div>
+    </button>
     <ul class="dropdown-menu" id="dropdown-menu">
       <li><a href="index.html">Home</a></li>
       <li><a href="about.html">About</a></li>


### PR DESCRIPTION
## Summary
- use a real button for the menu toggle across pages
- add ARIA attributes and adjust HTML markup
- enhance `script.js` to manage `aria-expanded` and close the menu on Escape or outside clicks

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68635c34af3c83299c3668f0d1e634ee