### PR TITLE
Remove inline contact scripts

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -40,7 +40,7 @@
 
     <div style="display: flex; gap: 1em; flex-wrap: wrap; align-items: center; margin-bottom: 2em;">
       <a href="mailto:info@scalesedge.com" class="button">Email Now</a>
-      <button class="button" onclick="copyEmail()">Copy Email</button>
+      <button class="button" id="copy-email-btn">Copy Email</button>
       <span id="copy-confirmation" style="display: none; color: #00cc66; font-weight: 500;">Copied!</span>
     </div>
 
@@ -58,42 +58,6 @@
     <p>© 2025 ScalesEdge. All rights reserved.</p>
   </footer>
 
-  <script>
-    function copyEmail() {
-      const email = "info@scalesedge.com";
-      navigator.clipboard.writeText(email).then(() => {
-        const confirmation = document.getElementById("copy-confirmation");
-        confirmation.style.display = "inline";
-        setTimeout(() => {
-          confirmation.style.display = "none";
-        }, 2000);
-      });
-    }
-
-    // Confirmation message on form submit
-    const form = document.getElementById("contact-form");
-    const status = document.getElementById("form-status");
-
-    form.addEventListener("submit", async function(event) {
-      event.preventDefault();
-      const data = new FormData(form);
-      const response = await fetch(form.action, {
-        method: form.method,
-        body: data,
-        headers: {
-          'Accept': 'application/json'
-        }
-      });
-
-      if (response.ok) {
-        form.reset();
-        status.style.display = "block";
-        setTimeout(() => {
-          status.style.display = "none";
-        }, 4000);
-      }
-    });
-  </script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
   }
   
   // Attach the copyEmail function to the button for email copy
-  const copyButton = document.querySelector('button[onclick="copyEmail()"]');
+  const copyButton = document.getElementById('copy-email-btn');
   if (copyButton) {
     copyButton.addEventListener('click', copyEmail);
   }


### PR DESCRIPTION
## Summary
- trim contact form markup by dropping the inline `<script>` block
- switch the copy email button to a dedicated id
- hook the contact page JS logic to that id

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68635c366e2c83299838786a04f08a0a